### PR TITLE
Add extra tag for 5155 to be appended to 5160 system "type" flag

### DIFF
--- a/src/arch/ibmpc/ibmpc.c
+++ b/src/arch/ibmpc/ibmpc.c
@@ -6,6 +6,7 @@
  * File name:   src/arch/ibmpc/ibmpc.c                                       *
  * Created:     1999-04-16 by Hampa Hug <hampa@hampa.ch>                     *
  * Copyright:   (C) 1999-2017 Hampa Hug <hampa@hampa.ch>                     *
+ *              (C) 2019 Dan FitzGerald <daniel.j.fitzgerald@gmail.com>      *
  *****************************************************************************/
 
 /*****************************************************************************
@@ -468,6 +469,9 @@ void pc_setup_system (ibmpc_t *pc, ini_sct_t *ini)
 
 	if (strcmp (model, "5150") == 0) {
 		pc->model = PCE_IBMPC_5150;
+	}
+	else if (strcmp (model, "5155") == 0){
+		pc->model = PCE_IBMPC_5160 | PCE_IBMPC_5155;
 	}
 	else if (strcmp (model, "5160") == 0) {
 		pc->model = PCE_IBMPC_5160;

--- a/src/arch/ibmpc/main.h
+++ b/src/arch/ibmpc/main.h
@@ -6,6 +6,7 @@
  * File name:   src/arch/ibmpc/main.h                                        *
  * Created:     2001-05-01 by Hampa Hug <hampa@hampa.ch>                     *
  * Copyright:   (C) 2001-2016 Hampa Hug <hampa@hampa.ch>                     *
+ *              (C) 2019 Dan FitzGerald <daniel.j.fitzgerald@gmail.com>      *
  *****************************************************************************/
 
 /*****************************************************************************
@@ -32,8 +33,9 @@
 #define PCE_IBMPC_CLK2 (PCE_IBMPC_CLK0 / 12)
 
 #define PCE_IBMPC_5150 1
-#define PCE_IBMPC_5160 2
-#define PCE_IBMPC_M24  4
+#define PCE_IBMPC_5155 2
+#define PCE_IBMPC_5160 4
+#define PCE_IBMPC_M24  8
 
 
 extern const char *par_terminal;


### PR DESCRIPTION
Add extra tag for IBM 5155 model type to be appended to 5160 model type flag.  Currently, this does nothing.  If we can figure out any important technical ways in which a 5155 differs from a 5160, we will use this tag in conditionals.